### PR TITLE
feat: Implement task management for work sessions

### DIFF
--- a/backend/backend/package-lock.json
+++ b/backend/backend/package-lock.json
@@ -1,0 +1,6 @@
+{
+  "name": "backend",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {}
+}

--- a/backend/migrations/20250910170916-add-fields-to-session-tasks.js
+++ b/backend/migrations/20250910170916-add-fields-to-session-tasks.js
@@ -1,0 +1,32 @@
+'use strict';
+
+module.exports = {
+  up: async (queryInterface, Sequelize) => {
+    await queryInterface.renameColumn('SessionTasks', 'description', 'title');
+    await queryInterface.addColumn('SessionTasks', 'description', {
+      type: Sequelize.TEXT,
+      allowNull: true,
+    });
+    await queryInterface.addColumn('SessionTasks', 'status', {
+      type: Sequelize.STRING,
+      allowNull: false,
+      defaultValue: 'pending',
+    });
+    await queryInterface.addColumn('SessionTasks', 'tags', {
+      type: Sequelize.TEXT,
+      allowNull: true,
+    });
+    await queryInterface.addColumn('SessionTasks', 'observations', {
+      type: Sequelize.TEXT,
+      allowNull: true,
+    });
+  },
+
+  down: async (queryInterface, Sequelize) => {
+    await queryInterface.renameColumn('SessionTasks', 'title', 'description');
+    await queryInterface.removeColumn('SessionTasks', 'description');
+    await queryInterface.removeColumn('SessionTasks', 'status');
+    await queryInterface.removeColumn('SessionTasks', 'tags');
+    await queryInterface.removeColumn('SessionTasks', 'observations');
+  }
+};

--- a/backend/src/controllers/taskController.js
+++ b/backend/src/controllers/taskController.js
@@ -1,0 +1,115 @@
+const { SessionTask, WorkSession } = require('../models');
+
+// @route   POST api/tasks
+// @desc    Create a task for a work session
+// @access  Private
+exports.createTask = async (req, res) => {
+  try {
+    const { workSessionId, title, description, tags, observations } = req.body;
+    const userId = req.user.userId;
+
+    const workSession = await WorkSession.findOne({ where: { id: workSessionId, userId } });
+    if (!workSession) {
+      return res.status(404).json({ message: 'Work session not found.' });
+    }
+
+    const newTask = await SessionTask.create({
+      workSessionId,
+      title,
+      description,
+      tags,
+      observations,
+      status: 'pending',
+    });
+
+    res.status(201).json(newTask);
+  } catch (error) {
+    res.status(500).json({ message: 'Server error', error: error.message });
+  }
+};
+
+// @route   GET api/tasks/session/:workSessionId
+// @desc    Get all tasks for a work session
+// @access  Private
+exports.getTasksForSession = async (req, res) => {
+  try {
+    const { workSessionId } = req.params;
+    const userId = req.user.userId;
+
+    const workSession = await WorkSession.findOne({ where: { id: workSessionId, userId } });
+    if (!workSession) {
+      return res.status(404).json({ message: 'Work session not found.' });
+    }
+
+    const tasks = await SessionTask.findAll({ where: { workSessionId } });
+
+    res.status(200).json(tasks);
+  } catch (error) {
+    res.status(500).json({ message: 'Server error', error: error.message });
+  }
+};
+
+// @route   PUT api/tasks/:id
+// @desc    Update a task
+// @access  Private
+exports.updateTask = async (req, res) => {
+  try {
+    const { id } = req.params;
+    const { title, description, status, tags, observations } = req.body;
+    const userId = req.user.userId;
+
+    const task = await SessionTask.findOne({
+      where: { id },
+      include: [{
+        model: WorkSession,
+        as: 'workSession',
+        where: { userId }
+      }]
+    });
+
+    if (!task) {
+      return res.status(404).json({ message: 'Task not found.' });
+    }
+
+    task.title = title || task.title;
+    task.description = description || task.description;
+    task.status = status || task.status;
+    task.tags = tags || task.tags;
+    task.observations = observations || task.observations;
+
+    await task.save();
+
+    res.status(200).json(task);
+  } catch (error) {
+    res.status(500).json({ message: 'Server error', error: error.message });
+  }
+};
+
+// @route   DELETE api/tasks/:id
+// @desc    Delete a task
+// @access  Private
+exports.deleteTask = async (req, res) => {
+  try {
+    const { id } = req.params;
+    const userId = req.user.userId;
+
+    const task = await SessionTask.findOne({
+      where: { id },
+      include: [{
+        model: WorkSession,
+        as: 'workSession',
+        where: { userId }
+      }]
+    });
+
+    if (!task) {
+      return res.status(404).json({ message: 'Task not found.' });
+    }
+
+    await task.destroy();
+
+    res.status(200).json({ message: 'Task deleted successfully.' });
+  } catch (error) {
+    res.status(500).json({ message: 'Server error', error: error.message });
+  }
+};

--- a/backend/src/models/SessionTask.js
+++ b/backend/src/models/SessionTask.js
@@ -18,7 +18,11 @@ module.exports = (sequelize, DataTypes) => {
     }
   }
   SessionTask.init({
+    title: DataTypes.TEXT,
     description: DataTypes.TEXT,
+    status: DataTypes.STRING,
+    tags: DataTypes.TEXT,
+    observations: DataTypes.TEXT,
     workSessionId: DataTypes.INTEGER
   }, {
     sequelize,

--- a/backend/src/routes/taskRoutes.js
+++ b/backend/src/routes/taskRoutes.js
@@ -1,0 +1,26 @@
+const express = require('express');
+const router = express.Router();
+const taskController = require('../controllers/taskController');
+const authMiddleware = require('../middleware/authMiddleware');
+
+// @route   POST api/tasks
+// @desc    Create a task for a work session
+// @access  Private
+router.post('/', authMiddleware, taskController.createTask);
+
+// @route   GET api/tasks/session/:workSessionId
+// @desc    Get all tasks for a work session
+// @access  Private
+router.get('/session/:workSessionId', authMiddleware, taskController.getTasksForSession);
+
+// @route   PUT api/tasks/:id
+// @desc    Update a task
+// @access  Private
+router.put('/:id', authMiddleware, taskController.updateTask);
+
+// @route   DELETE api/tasks/:id
+// @desc    Delete a task
+// @access  Private
+router.delete('/:id', authMiddleware, taskController.deleteTask);
+
+module.exports = router;

--- a/backend/src/server.js
+++ b/backend/src/server.js
@@ -24,6 +24,9 @@ app.use('/api/timer', timerRoutes);
 const reportRoutes = require('./routes/reportRoutes');
 app.use('/api/reports', reportRoutes);
 
+const taskRoutes = require('./routes/taskRoutes');
+app.use('/api/tasks', taskRoutes);
+
 const PORT = process.env.PORT || 3001;
 
 app.listen(PORT, () => {

--- a/frontend/src/components/TaskList.tsx
+++ b/frontend/src/components/TaskList.tsx
@@ -1,0 +1,174 @@
+import React, { useState, useEffect, useCallback } from 'react';
+import { Box, Button, Typography, TextField, Checkbox, IconButton, List, ListItem, ListItemText, Collapse, Paper, Tooltip } from '@mui/material';
+import { Edit, Delete, Comment } from '@mui/icons-material';
+import * as taskService from '../services/taskService';
+import { Task } from '../services/taskService';
+
+interface TaskListProps {
+  workSessionId: number;
+}
+
+const TaskList: React.FC<TaskListProps> = ({ workSessionId }) => {
+  const [tasks, setTasks] = useState<Task[]>([]);
+  const [newTaskTitle, setNewTaskTitle] = useState('');
+  const [editingTask, setEditingTask] = useState<Task | null>(null);
+  const [openObservations, setOpenObservations] = useState<number | null>(null);
+
+  const fetchTasks = useCallback(async () => {
+    try {
+      const res = await taskService.getTasksForSession(workSessionId);
+      setTasks(res.data);
+    } catch (error) {
+      console.error('Failed to fetch tasks', error);
+    }
+  }, [workSessionId]);
+
+  useEffect(() => {
+    fetchTasks();
+  }, [fetchTasks]);
+
+  const handleCreateTask = async () => {
+    if (!newTaskTitle.trim()) return;
+    try {
+      await taskService.createTask({ workSessionId, title: newTaskTitle });
+      setNewTaskTitle('');
+      fetchTasks();
+    } catch (error) {
+      console.error('Failed to create task', error);
+    }
+  };
+
+  const handleUpdateTask = async (task: Task) => {
+    try {
+      await taskService.updateTask(task.id, task);
+      setEditingTask(null);
+      fetchTasks();
+    } catch (error) {
+      console.error('Failed to update task', error);
+    }
+  };
+
+  const handleDeleteTask = async (id: number) => {
+    try {
+      await taskService.deleteTask(id);
+      fetchTasks();
+    } catch (error) {
+      console.error('Failed to delete task', error);
+    }
+  };
+
+  const toggleTaskStatus = (task: Task) => {
+    const newStatus = task.status === 'pending' ? 'completed' : 'pending';
+    handleUpdateTask({ ...task, status: newStatus });
+  };
+
+  const handleToggleObservations = (taskId: number) => {
+    setOpenObservations(openObservations === taskId ? null : taskId);
+  };
+
+  const renderTask = (task: Task) => (
+    <Paper key={task.id} sx={{ mb: 1 }}>
+      <ListItem
+        secondaryAction={
+          <>
+            <Tooltip title="Observations">
+              <IconButton edge="end" aria-label="observations" onClick={() => handleToggleObservations(task.id)} disabled={!task.observations}>
+                <Comment color={task.observations ? "primary" : "disabled"}/>
+              </IconButton>
+            </Tooltip>
+            <Tooltip title="Edit">
+              <IconButton edge="end" aria-label="edit" onClick={() => setEditingTask(task)}>
+                <Edit />
+              </IconButton>
+            </Tooltip>
+            <Tooltip title="Delete">
+              <IconButton edge="end" aria-label="delete" onClick={() => handleDeleteTask(task.id)}>
+                <Delete />
+              </IconButton>
+            </Tooltip>
+          </>
+        }
+      >
+        <Checkbox
+          edge="start"
+          checked={task.status === 'completed'}
+          tabIndex={-1}
+          disableRipple
+          onChange={() => toggleTaskStatus(task)}
+        />
+        <ListItemText primary={task.title} sx={{ textDecoration: task.status === 'completed' ? 'line-through' : 'none' }} />
+      </ListItem>
+      <Collapse in={openObservations === task.id} timeout="auto" unmountOnExit>
+        <Box sx={{ p: 2, borderTop: '1px solid #eee' }}>
+          <Typography variant="body2">{task.observations}</Typography>
+        </Box>
+      </Collapse>
+    </Paper>
+  );
+
+  const renderEditForm = (task: Task) => (
+    <Paper sx={{ p: 2, mb: 1 }}>
+        <TextField
+            label="Title"
+            fullWidth
+            value={task.title}
+            onChange={(e) => setEditingTask({ ...task, title: e.target.value })}
+            sx={{ mb: 1 }}
+        />
+        <TextField
+            label="Description"
+            fullWidth
+            multiline
+            rows={2}
+            value={task.description || ''}
+            onChange={(e) => setEditingTask({ ...task, description: e.target.value })}
+            sx={{ mb: 1 }}
+        />
+        <TextField
+            label="Tags (comma-separated)"
+            fullWidth
+            value={task.tags || ''}
+            onChange={(e) => setEditingTask({ ...task, tags: e.target.value })}
+            sx={{ mb: 1 }}
+        />
+        <TextField
+            label="Observations"
+            fullWidth
+            multiline
+            rows={3}
+            value={task.observations || ''}
+            onChange={(e) => setEditingTask({ ...task, observations: e.target.value })}
+            sx={{ mb: 1 }}
+        />
+        <Box sx={{ display: 'flex', justifyContent: 'flex-end', gap: 1 }}>
+            <Button onClick={() => setEditingTask(null)}>Cancel</Button>
+            <Button variant="contained" onClick={() => handleUpdateTask(task)}>Save</Button>
+        </Box>
+    </Paper>
+  );
+
+  return (
+    <Box sx={{ mt: 2 }}>
+      <Typography variant="h6">Tasks</Typography>
+      <Box sx={{ display: 'flex', gap: 1, mb: 2 }}>
+        <TextField
+          label="New Task Title"
+          variant="outlined"
+          size="small"
+          fullWidth
+          value={newTaskTitle}
+          onChange={(e) => setNewTaskTitle(e.target.value)}
+          onKeyPress={(e) => e.key === 'Enter' && handleCreateTask()}
+        />
+        <Button variant="contained" onClick={handleCreateTask}>Add</Button>
+      </Box>
+      <List>
+        {tasks.map(task => (
+            editingTask && editingTask.id === task.id ? renderEditForm(editingTask) : renderTask(task)
+        ))}
+      </List>
+    </Box>
+  );
+};
+
+export default TaskList;

--- a/frontend/src/components/Timer.tsx
+++ b/frontend/src/components/Timer.tsx
@@ -4,6 +4,7 @@ import * as timerService from '../services/timerService';
 import * as clientService from '../services/clientService';
 import { WorkSession } from '../services/timerService';
 import { Client } from '../services/clientService';
+import TaskList from './TaskList';
 
 const Timer: React.FC = () => {
   const [session, setSession] = useState<WorkSession | null>(null);
@@ -156,7 +157,7 @@ const Timer: React.FC = () => {
           ))}
         </Select>
       </FormControl>
-      {/* TaskList will go here */}
+      {session && <TaskList workSessionId={session.id} />}
     </Box>
   );
 };

--- a/frontend/src/services/taskService.ts
+++ b/frontend/src/services/taskService.ts
@@ -1,0 +1,29 @@
+import api from './api';
+
+export interface Task {
+  id: number;
+  workSessionId: number;
+  title: string;
+  description?: string;
+  status: 'pending' | 'completed';
+  tags?: string;
+  observations?: string;
+  createdAt: string;
+  updatedAt:string;
+}
+
+export const getTasksForSession = (workSessionId: number): Promise<{ data: Task[] }> => {
+  return api.get(`/tasks/session/${workSessionId}`);
+};
+
+export const createTask = (taskData: Partial<Task>): Promise<{ data: Task }> => {
+  return api.post('/tasks', taskData);
+};
+
+export const updateTask = (id: number, taskData: Partial<Task>): Promise<{ data: Task }> => {
+  return api.put(`/tasks/${id}`, taskData);
+};
+
+export const deleteTask = (id: number): Promise<void> => {
+  return api.delete(`/tasks/${id}`);
+};

--- a/install_backend.sh
+++ b/install_backend.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+cd backend
+npm install

--- a/migrate_backend.sh
+++ b/migrate_backend.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+cd backend
+npm run sequeliza:migrate

--- a/start_backend.sh
+++ b/start_backend.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+cd backend
+npm run dev > ../backend.log 2>&1 &

--- a/start_frontend.sh
+++ b/start_frontend.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+cd frontend
+npm install
+npm start > ../frontend.log 2>&1 &


### PR DESCRIPTION
This commit introduces a new feature that allows users to manage tasks associated with their work sessions.

**Backend:**
- Adds a database migration to extend the `SessionTasks` table with fields for title, description, status, tags, and observations.
- Implements a new set of API endpoints (`/api/tasks`) for performing CRUD operations on tasks.
- Ensures that all task-related operations are authorized and scoped to the current user's work sessions.

**Frontend:**
- Creates a new `TaskList` component to display and manage tasks within a work session.
- The component allows for creating, editing, deleting, and marking tasks as complete.
- Includes a feature to toggle the visibility of task observations.
- Integrates the `TaskList` component into the main `Timer` view, making it available during active sessions.
- Adds a `taskService` to handle communication with the backend API.